### PR TITLE
Unify main.yml

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,6 +2,10 @@
 # WARNING: This may not be your desired MGMT address.
 openstack_nova_controller_nova_my_ip: '{{ ansible_default_ipv4.address }}'
 
+# Database
+openstack_nova_database_schema_version: 319
+openstack_nova_api_database_schema_version: 7
+
 # RabbitMQ
 openstack_nova_controller_rabbit_hostname: 'localhost'
 openstack_nova_controller_rabbit_username: 'rabbit_username_default'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,22 +1,5 @@
 ---
 
-- name: 'Sync nova database'
-  command: 'nova-manage db sync'
-  become: True
-  become_user: 'nova'
-  notify:
-    - 'Restart nova controller services'
-
-- name: 'Sync nova API database'
-  command: 'nova-manage api_db sync'
-  become: True
-  become_user: 'nova'
-  notify:
-    - 'Restart nova controller services'
-
-- name: Daemon reload
-  command: 'systemctl daemon-reload'
-
 - name: Restart nova controller services
   service:
     name: '{{ item }}'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -1,21 +1,5 @@
 ---
 
-# Changing to 'simple' type to prevent hard dependency on other roles
-# See: http://lists.openstack.org/pipermail/openstack-dev/2015-December/083095.html
-- name: Fix systemd type
-  lineinfile:
-    dest: '/usr/lib/systemd/system/openstack-{{ item }}.service'
-    regexp: '^Type=notify$'
-    line: 'Type=simple'
-    backrefs: True
-  with_items:
-    - nova-api
-    - nova-conductor
-    - nova-scheduler
-    - nova-console
-  when: ansible_os_family == 'RedHat'
-  notify: Daemon reload
-
 - name: Configure nova controller
   ini_file:
     dest: /etc/nova/nova.conf
@@ -56,13 +40,22 @@
       value: keystone
     - section: keystone_authtoken
       option: identity_uri
-      value: '{{ openstack_nova_controller_keystone_protocol }}://{{ openstack_nova_controller_keystone_hostname }}:{{ openstack_nova_controller_keystone_admin_port }}'
+      value: >-
+        {{- openstack_nova_controller_keystone_protocol }}://
+        {{- openstack_nova_controller_keystone_hostname }}:
+        {{- openstack_nova_controller_keystone_admin_port }}
     - section: keystone_authtoken
       option: auth_url
-      value: '{{ openstack_nova_controller_keystone_protocol }}://{{ openstack_nova_controller_keystone_hostname }}:{{ openstack_nova_controller_keystone_admin_port }}'
+      value: >-
+        {{- openstack_nova_controller_keystone_protocol }}://
+        {{- openstack_nova_controller_keystone_hostname }}:
+        {{- openstack_nova_controller_keystone_admin_port }}
     - section: keystone_authtoken
       option: auth_uri
-      value: '{{ openstack_nova_controller_keystone_protocol }}://{{ openstack_nova_controller_keystone_hostname }}:{{ openstack_nova_controller_keystone_port }}/v3'
+      value: >-
+        {{- openstack_nova_controller_keystone_protocol }}://
+        {{- openstack_nova_controller_keystone_hostname }}:
+        {{- openstack_nova_controller_keystone_port }}/v3
     - section: keystone_authtoken
       option: project_domain_name
       value: default
@@ -114,12 +107,45 @@
     # Glance
     - section: glance
       option: api_servers
-      value: '{{ openstack_nova_controller_glance_protocol }}://{{ openstack_nova_controller_glance_hostname }}:{{ openstack_nova_controller_glance_port }}'
+      value: >-
+        {{- openstack_nova_controller_glance_protocol }}://
+        {{- openstack_nova_controller_glance_hostname }}:
+        {{- openstack_nova_controller_glance_port }}
     # Oslo
     - section: oslo_concurrency
       option: lock_path
       value: /var/lib/nova/tmp
   notify:
-    - Sync nova database
-    - Sync nova API database
     - Restart nova controller services
+
+- name: Get current Nova database version
+  command: 'nova-manage db version'
+  always_run: True
+  become: True
+  become_user: 'nova'
+  changed_when: openstack_nova_manage_db_version.stdout|int != openstack_nova_database_schema_version
+  register: openstack_nova_manage_db_version
+
+- name: Migrate Nova database to desired version
+  command: 'nova-manage db sync {{ openstack_nova_database_schema_version }}'
+  become: True
+  become_user: 'nova'
+  notify:
+    - Restart nova controller services
+  when: openstack_nova_manage_db_version|changed
+
+- name: Get current Nova API database version
+  command: 'nova-manage api_db version'
+  always_run: True
+  become: True
+  become_user: 'nova'
+  changed_when: openstack_nova_manage_api_db_version.stdout|int != openstack_nova_api_database_schema_version
+  register: openstack_nova_manage_api_db_version
+
+- name: Migrate Nova API database to desired version
+  command: 'nova-manage api_db sync {{ openstack_nova_api_database_schema_version }}'
+  become: True
+  become_user: 'nova'
+  notify:
+    - Restart nova controller services
+  when: openstack_nova_manage_api_db_version|changed

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,9 +1,17 @@
 ---
 
+- include: facts.yml
+
+- include: packages_redhat.yml
+  when: ansible_os_family == 'RedHat'
+
+- include: packages_debian.yml
+  when: ansible_os_family == 'Debian'
+
+- include: configuration.yml
+
+- include: services.yml
+
 - meta: flush_handlers
 
-- include: facts.yml
-- include: packages.yml
-- include: configuration.yml
-- meta: flush_handlers
 - include: sanitycheck.yml

--- a/tasks/packages.yml
+++ b/tasks/packages.yml
@@ -1,7 +1,0 @@
----
-
-- include: packages_redhat.yml
-  when: ansible_os_family == 'RedHat'
-
-- include: packages_debian.yml
-  when: ansible_os_family == 'Debian'

--- a/tasks/services.yml
+++ b/tasks/services.yml
@@ -1,0 +1,44 @@
+---
+
+- block:
+    - name: 'Create drop-in directory for nova services'
+      file:
+        path: '/etc/systemd/system/{{ item }}.service.d'
+        state: directory
+      with_items:
+        - '{{ openstack_nova_controller_nova_api_service }}'
+        - '{{ openstack_nova_controller_nova_conductor_service }}'
+        - '{{ openstack_nova_controller_nova_consoleauth_service }}'
+        - '{{ openstack_nova_controller_nova_scheduler_service }}'
+
+    # Changing to 'simple' type to prevent hard dependency on other roles
+    # See: http://lists.openstack.org/pipermail/openstack-dev/2015-December/083095.html
+    - name: 'Fix systemd type for nova services'
+      copy:
+        content: |
+          [Service]
+          Type=simple
+        dest: '/etc/systemd/system/{{ item }}.service.d/type.conf'
+      register: openstack_nova_controller_service_d_type_conf
+      with_items:
+        - '{{ openstack_nova_controller_nova_api_service }}'
+        - '{{ openstack_nova_controller_nova_conductor_service }}'
+        - '{{ openstack_nova_controller_nova_consoleauth_service }}'
+        - '{{ openstack_nova_controller_nova_scheduler_service }}'
+
+    - name: 'Reload systemd manager configuration'
+      command: 'systemctl daemon-reload'
+      when: openstack_nova_controller_service_d_type_conf|changed
+  when: ansible_os_family == 'RedHat'
+
+- name: Start and enable services
+  service:
+    enabled: True
+    name: '{{ item }}'
+    state: started
+  with_items:
+    - '{{ openstack_nova_controller_nova_api_service }}'
+    - '{{ openstack_nova_controller_nova_conductor_service }}'
+    - '{{ openstack_nova_controller_nova_consoleauth_service }}'
+    - '{{ openstack_nova_controller_nova_novncproxy_service }}'
+    - '{{ openstack_nova_controller_nova_scheduler_service }}'


### PR DESCRIPTION
Unify `main.yml` to a standard set of includes, with improved service
handling, improved database migration and unnecessary tasks removed.
Also, wrapped around some long lines.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
