### PR TITLE
Remove Branch Name From requirements.yml

### DIFF
--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -9,4 +9,3 @@
 - src: 'https://github.com/openstack-ansible-galaxy/rabbitmq.git'
 
 - src: 'https://github.com/openstack-ansible-galaxy/openstack-keystone'
-  version: 'origin/features/mitaka'


### PR DESCRIPTION
Since `openstack-keystone` role changed its branch name from
`features/mitaka` to `master`, Ansible Galaxy `requirements.yml` for
this role needs to change it as well.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
