### PR TITLE
Change yamllint line-length

### DIFF
--- a/.yamllint.conf
+++ b/.yamllint.conf
@@ -4,4 +4,4 @@ extends: default
 
 rules:
   line-length:
-    max: 170
+    max: 160

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -4,7 +4,10 @@
   shell: >-
     openstack
     --os-identity-api-version 3
-    --os-auth-url {{ openstack_nova_controller_keystone_protocol }}://{{ openstack_nova_controller_keystone_hostname }}:{{ openstack_nova_controller_keystone_port }}/v3
+    --os-auth-url
+    {{  openstack_nova_controller_keystone_protocol }}://
+    {{- openstack_nova_controller_keystone_hostname }}:
+    {{- openstack_nova_controller_keystone_port }}/v3
     --os-project-name "{{ openstack_nova_controller_demo_project }}"
     --os-username "{{ openstack_nova_controller_demo_user }}"
     --os-auth-type password


### PR DESCRIPTION
Due to the modification of Ansible Role Style Guide, yamllint check
needs to be modified.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
