### PR TITLE
Wait for Nova API to Become Available

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -37,3 +37,7 @@ openstack_nova_controller_neutron_password: 'neutron_pass_default'
 openstack_nova_controller_neutron_port: 9696
 openstack_nova_controller_neutron_protocol: 'http'
 openstack_nova_controller_neutron_username: 'neutron'
+
+# Sanity Check
+openstack_nova_controller_sanitycheck_address: 'localhost'
+openstack_nova_controller_sanitycheck_port: 8774

--- a/tasks/sanitycheck.yml
+++ b/tasks/sanitycheck.yml
@@ -1,5 +1,11 @@
 ---
 
+- name: Wait for nova-api service to become available
+  wait_for:
+    host: '{{ openstack_nova_controller_sanitycheck_address  }}'
+    port: '{{ openstack_nova_controller_sanitycheck_port }}'
+    delay: 3
+
 - name: SANITY CHECK List nova instances
   shell: >-
     openstack


### PR DESCRIPTION
On system with systemd, `systemctl restart openstack-nova-api` command
returning does not necessarily mean that openstack-nova-api service is
ready to accept connection.  Actually wait for the port to be open and
then continue on the sanity check.

Signed-off-by: Ryo Tagami rtagami@airstrip.jp
