### PR TITLE
Fix Ansible 2.2 Incompatibility

### DIFF
--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -1,5 +1,11 @@
 ---
+
 # MariaDB
+mysql_root_password: 'mysqlpassword'
+mysql_bind_address: '0.0.0.0'
+# mysql_character_set_server: 'utf8'
+# mysql_collation_server: 'utf8_general_ci'
+mysql_innodb_file_per_table: 'innodb_file_per_table'
 mysql_databases:
   - name: 'keystone'
   - name: 'glance'

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -16,25 +16,5 @@
           password: 'rabbit_pass_default'
 
     - role: mysql
-      mysql_daemon: 'mysql'
-      mysql_root_password: 'mysqlpassword'
-      mysql_bind_address: 0.0.0.0
-      mysql_innodb_file_per_table: 'innodb_file_per_table'
-      mysql_packages:
-        - mariadb-client
-        - mariadb-server
-        - python-mysqldb
-      when: ansible_os_family == 'Debian'
-
-    - role: mysql
-      mysql_root_password: 'mysqlpassword'
-      mysql_bind_address: 0.0.0.0
-      mysql_innodb_file_per_table: 'innodb_file_per_table'
-      mysql_daemon: 'mariadb'
-      mysql_log_error: '/var/log/mariadb/mariadb.log'
-      mysql_syslog_tag: 'mariadb'
-      mysql_pid_file: '/var/run/mariadb/mariadb.pid'
-      when: ansible_os_family == 'RedHat'
-
     - role: openstack-keystone
     - role: openstack-nova-controller

--- a/tests/test_common.yml
+++ b/tests/test_common.yml
@@ -4,9 +4,30 @@
   become: True
 
   pre_tasks:
+    - name: Set facts for mysql role on Debian based system
+      set_fact:
+        mysql_daemon: 'mysql'
+        mysql_log_error: '/var/log/mysql/error.log'
+        mysql_pid_file: '/var/run/mysqld/mysqld.pid'
+        mysql_packages:
+          - 'mariadb-client'
+          - 'mariadb-server'
+          - 'python-mysqldb'
+      when: ansible_os_family == 'Debian'
+
+    - name: Set facts for mysql role on RedHat based system
+      set_fact:
+        mysql_daemon: 'mariadb'
+        mysql_socket: '/var/lib/mysql/mysql.sock'
+        mysql_log_error: '/var/log/mariadb/mariadb.log'
+        mysql_syslog_tag: 'mariadb'
+        mysql_pid_file: '/var/run/mariadb/mariadb.pid'
+      when: ansible_os_family == 'RedHat'
+
     - name: Update local apt cache (Ubuntu)
       apt:
         update_cache: True
+      changed_when: False
       when: ansible_os_family == 'Debian'
 
     - name: Install policycoreutils-python


### PR DESCRIPTION
On Ansbile 2.2, `mysql` role will not work anymore with the current
style of parameter passing.  Fix will be to pass all parameters to
`mysql` role regardless of the `ansible_os_family`.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>