### PR TITLE
Dynamic Database Migration Version Detection

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,10 +2,6 @@
 # WARNING: This may not be your desired MGMT address.
 openstack_nova_controller_nova_my_ip: '{{ ansible_default_ipv4.address }}'
 
-# Database
-openstack_nova_database_schema_version: 319
-openstack_nova_api_database_schema_version: 7
-
 # RabbitMQ
 openstack_nova_controller_rabbit_hostname: 'localhost'
 openstack_nova_controller_rabbit_username: 'rabbit_username_default'

--- a/tasks/configuration.yml
+++ b/tasks/configuration.yml
@@ -148,32 +148,52 @@
   notify:
     - Restart nova controller services
 
+- name: Get latest Nova database version
+  shell: >-
+    ls {{ openstack_nova_database_migration_repository }}
+    | grep '^[0-9]\{3\}_' | sort -n | tail -n 1 | awk -F '_' '{ print $1; }'
+  always_run: True
+  changed_when: False
+  register: openstack_nova_database_schema_version
+
 - name: Get current Nova database version
   command: 'nova-manage db version'
   always_run: True
   become: True
   become_user: 'nova'
-  changed_when: openstack_nova_manage_db_version.stdout|int != openstack_nova_database_schema_version
+  changed_when: >-
+    openstack_nova_manage_db_version.stdout|int
+    != openstack_nova_database_schema_version.stdout|int
   register: openstack_nova_manage_db_version
 
 - name: Migrate Nova database to desired version
-  command: 'nova-manage db sync {{ openstack_nova_database_schema_version }}'
+  command: 'nova-manage db sync {{ openstack_nova_database_schema_version.stdout }}'
   become: True
   become_user: 'nova'
   notify:
     - Restart nova controller services
   when: openstack_nova_manage_db_version|changed
 
+- name: Get latest Nova API database version
+  shell: >-
+    ls {{ openstack_nova_api_database_migration_repository }}
+    | grep '^[0-9]\{3\}_' | sort -n | tail -n 1 | awk -F '_' '{ print $1; }'
+  always_run: True
+  changed_when: False
+  register: openstack_nova_api_database_schema_version
+
 - name: Get current Nova API database version
   command: 'nova-manage api_db version'
   always_run: True
   become: True
   become_user: 'nova'
-  changed_when: openstack_nova_manage_api_db_version.stdout|int != openstack_nova_api_database_schema_version
+  changed_when: >-
+    openstack_nova_manage_api_db_version.stdout|int
+    != openstack_nova_api_database_schema_version.stdout|int
   register: openstack_nova_manage_api_db_version
 
 - name: Migrate Nova API database to desired version
-  command: 'nova-manage api_db sync {{ openstack_nova_api_database_schema_version }}'
+  command: 'nova-manage api_db sync {{ openstack_nova_api_database_schema_version.stdout }}'
   become: True
   become_user: 'nova'
   notify:

--- a/tasks/facts.yml
+++ b/tasks/facts.yml
@@ -1,51 +1,27 @@
 ---
 
-- name: Set nova API service facts
+- name: Set nova-controller facts
   set_fact:
-    openstack_nova_controller_nova_api_service: nova-api
+    openstack_nova_controller_nova_api_service: 'nova-api'
+    openstack_nova_controller_nova_conductor_service: 'nova-conductor'
+    openstack_nova_controller_nova_consoleauth_service: 'nova-consoleauth'
+    openstack_nova_controller_nova_novncproxy_service: 'nova-novncproxy'
+    openstack_nova_controller_nova_scheduler_service: 'nova-scheduler'
+    openstack_nova_database_migration_repository: >-
+      /usr/lib/python2.7/dist-packages/nova/db/sqlalchemy/migrate_repo/versions
+    openstack_nova_api_database_migration_repository: >-
+      /usr/lib/python2.7/dist-packages/nova/db/sqlalchemy/api_migrations/migrate_repo/versions
   when: ansible_os_family == 'Debian'
 
-- name: Set nova API service facts
+- name: Set nova-controller facts
   set_fact:
-    openstack_nova_controller_nova_api_service: openstack-nova-api
-  when: ansible_os_family == 'RedHat'
-
-- name: Set nova conductor service facts
-  set_fact:
-    openstack_nova_controller_nova_conductor_service: nova-conductor
-  when: ansible_os_family == 'Debian'
-
-- name: Set nova conductor service facts
-  set_fact:
-    openstack_nova_controller_nova_conductor_service: openstack-nova-conductor
-  when: ansible_os_family == 'RedHat'
-
-- name: Set nova consoleauth service facts
-  set_fact:
-    openstack_nova_controller_nova_consoleauth_service: nova-consoleauth
-  when: ansible_os_family == 'Debian'
-
-- name: Set nova consoleauth service facts
-  set_fact:
-    openstack_nova_controller_nova_consoleauth_service: openstack-nova-consoleauth
-  when: ansible_os_family == 'RedHat'
-
-- name: Set nova novncproxy service facts
-  set_fact:
-    openstack_nova_controller_nova_novncproxy_service: nova-novncproxy
-  when: ansible_os_family == 'Debian'
-
-- name: Set nova novncproxy service facts
-  set_fact:
-    openstack_nova_controller_nova_novncproxy_service: openstack-nova-novncproxy
-  when: ansible_os_family == 'RedHat'
-
-- name: Set nova scheduler service facts
-  set_fact:
-    openstack_nova_controller_nova_scheduler_service: nova-scheduler
-  when: ansible_os_family == 'Debian'
-
-- name: Set nova scheduler service facts
-  set_fact:
-    openstack_nova_controller_nova_scheduler_service: openstack-nova-scheduler
+    openstack_nova_controller_nova_api_service: 'openstack-nova-api'
+    openstack_nova_controller_nova_conductor_service: 'openstack-nova-conductor'
+    openstack_nova_controller_nova_consoleauth_service: 'openstack-nova-consoleauth'
+    openstack_nova_controller_nova_novncproxy_service: 'openstack-nova-novncproxy'
+    openstack_nova_controller_nova_scheduler_service: 'openstack-nova-scheduler'
+    openstack_nova_database_migration_repository: >-
+      /usr/lib/python2.7/site-packages/nova/db/sqlalchemy/migrate_repo/versions
+    openstack_nova_api_database_migration_repository: >-
+      /usr/lib/python2.7/site-packages/nova/db/sqlalchemy/api_migrations/migrate_repo/versions
   when: ansible_os_family == 'RedHat'


### PR DESCRIPTION
Dynamically detect the latest database migration version, instead of
hardcoding the latest database migration version, which is difficult to
keep up with the upstream changes.

Signed-off-by: Ryo Tagami <rtagami@airstrip.jp>